### PR TITLE
Fix Status Node: stop without continue

### DIFF
--- a/amlip_cpp/src/cpp/dds/Reader.hpp
+++ b/amlip_cpp/src/cpp/dds/Reader.hpp
@@ -56,6 +56,8 @@ public:
 
     void awake_waiting_threads();
 
+    void stop();
+
     bool is_data_available();
 
     T read();

--- a/amlip_cpp/src/cpp/dds/impl/Reader.ipp
+++ b/amlip_cpp/src/cpp/dds/impl/Reader.ipp
@@ -81,6 +81,12 @@ void Reader<T>::awake_waiting_threads()
 }
 
 template <typename T>
+void Reader<T>::stop()
+{
+    reader_data_waiter_.blocking_disable();
+}
+
+template <typename T>
 bool Reader<T>::is_data_available()
 {
     return reader_data_waiter_.is_open();

--- a/amlip_cpp/src/cpp/node/StatusNode.cpp
+++ b/amlip_cpp/src/cpp/node/StatusNode.cpp
@@ -114,7 +114,7 @@ void StatusNode::stop_processing()
     if (processing_)
     {
         processing_ = false;
-        status_reader_->awake_waiting_threads(); // This must awake thread and it must finish
+        status_reader_->stop(); // This must awake thread and it must finish
         process_thread_.join();
 
         change_status_(types::StateKind::stopped);


### PR DESCRIPTION
Currently, the method awake_waiting_threads() is utilized to halt the processing, invoking stop_and_continue(). However, this approach introduces a potential problem: if a thread is created after this call, there is no mechanism to stop it from running.

Replacing the use of awake_waiting_threads() with the stop() method. By calling stop() we call the blocking_disable(). This will prevent new threads from being created afterwards.

We kindly request you to review the changes and provide your valuable feedback on this proposed enhancement.