### PR TITLE
Declare to string method for GenericDataType and AmlipIdDataType

### DIFF
--- a/amlip_swig/src/swig/amlip_swig/types/GenericDataType.i
+++ b/amlip_swig/src/swig/amlip_swig/types/GenericDataType.i
@@ -25,6 +25,14 @@
 %ignore eprosima::amlip::types::GenericDataType::data_size();
 %rename("%s") eprosima::amlip::types::GenericDataType::data_size() const;
 
+// Declare the to string method
+%extend eprosima::amlip::types::GenericDataType {
+    std::string __str__() const
+    {
+        return $self->to_string();
+    }
+}
+
 %{
 #include <amlip_cpp/types/GenericDataType.hpp>
 %}

--- a/amlip_swig/src/swig/amlip_swig/types/id/AmlipIdDataType.i
+++ b/amlip_swig/src/swig/amlip_swig/types/id/AmlipIdDataType.i
@@ -26,6 +26,14 @@
 %ignore eprosima::amlip::types::AmlipIdDataType::id();
 %rename("%s") eprosima::amlip::types::AmlipIdDataType::id() const;
 
+// Declare the to string method
+%extend eprosima::amlip::types::AmlipIdDataType {
+    std::string __str__() const
+    {
+        return $self->to_string();
+    }
+}
+
 %{
 #include <amlip_cpp/types/id/AmlipIdDataType.hpp>
 %}


### PR DESCRIPTION
Added a `__str__()` method to `AmlipIdDataType` and `GenericDataType`. This method returns a string representation of the object by calling its `to_string()` method.

Previously, the default representation was generic and uninformative:

`<amlip_swig.AmlipIdDataType; proxy of <Swig Object of type 'eprosima::amlip::types::AmlipIdDataType *' at 0x74eabaf50960> >`

With the addition of `__str__()`, the output becomes descriptive:

`AMLMainNode.89.8e.a5.7f`